### PR TITLE
Tweak - Fix border issue on the first post

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -44,6 +44,7 @@ and we will include it within the theme from next version update.
 
 == Changelog ==
 = TBD =
+* Fix - Border issue on the first post.
 * Enhancement - Update protocol to prevent not secure issue.
 * Add   - Required header fields: `Tested up to` and `Requires PHP` in style.css.
 * Tweak - Add and improve theme-related notices.

--- a/style.css
+++ b/style.css
@@ -973,9 +973,6 @@ footer .blog-post{
 .entry-title {
 	border-bottom:thin solid #eaeaea;
 }
-.sticky {
-	border:1px solid #ffc800;
-}
 .entry-author:before, .entry-date:before, .entry-standard:before {
 	margin:0 5px 0 0;
 }


### PR DESCRIPTION
# Description
- I've fixed the border issue on the first post of Masonic theme.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Changelog
- Fix - Border issue on the first post.
# Did you test this issue fix on all browsers?
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer
# Checklist:
- [x] My code follows the WPCS
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have made perform test that proves my fix is effective or that my feature works